### PR TITLE
fix: can't use function at keymap_set in Vim

### DIFF
--- a/lua/artemis.lua
+++ b/lua/artemis.lua
@@ -171,7 +171,7 @@ local function keymap_set(modes, lhs, rhs, opts)
       end
     end
     table.insert(args, lhs)
-    if type(lhs) == 'function' then
+    if type(rhs) == 'function' then
       M._keymap[lhs] = rhs
       table.insert(args, 'lua require"artemis"._keymap[ [=['..lhs..']=] ]()')
     else


### PR DESCRIPTION
# Problem

Can't use function at keymap_set in Vim

# To Reproduce

1. introduce vimrc

```vim
set rtp+=/path/to/vim-artemis

lua << EOF
require('artemis').keymap.set('n', 'a', function() end)
EOF
```

2. Run vim

`$ vim -u vimrc -N`

3. Occur error

```
Error detected while processing /tmp/vimrc:
line    6:
/data/vim/repos/github.com/tani/vim-artemis/lua/artemis.lua:446: attempt to concatenate local 'arg' (a function value)
```

# Note
It fixes #1