### PR TITLE
Fix pcall return value order

### DIFF
--- a/lua/artemis.lua
+++ b/lua/artemis.lua
@@ -241,7 +241,7 @@ local vars = setmetatable({}, {
       end,
       __index = function(var, name)
         local expr = scope .. ':' .. var.__name .. '["' .. name .. '"]'
-        local val, err = pcall(M.eval, expr)
+        local err, val = pcall(M.eval, expr)
         if type(val) == 'table' then
           val.__name = var.__name .. '["' .. name .. '"]'
           setmetatable(val, getmetatable(var))


### PR DESCRIPTION
pcall return return(boolean) as first.

ref: https://www.lua.org/pil/8.4.html


> The pcall function calls its first argument in protected mode, so that it catches any errors while the function is running. If there are no errors, pcall returns true, plus any values returned by the call. Otherwise, it returns false, plus the error message.
