### PR TITLE
fix: check if the target type is function

### DIFF
--- a/lua/artemis.lua
+++ b/lua/artemis.lua
@@ -102,9 +102,9 @@ M.delete_command = function(name)
   M.cmd.delcommand(name)
 end
 
-M.dict = vim.dict or function(x) return x end
-M.list = vim.list or function(x) return x end
-M.blob = vim.blob or function(x) return x end
+M.dict = type(vim.dict) == 'function' and vim.dict or function(x) return x end
+M.list = type(vim.list) == 'function' and vim.list or function(x) return x end
+M.blob = type(vim.dict) == 'function' and vim.blob or function(x) return x end
 function M.cast(t)
   if type(t) ~= 'table' then
     return t


### PR DESCRIPTION
nvim implemented `vim.list.unique()` at https://github.com/neovim/neovim/commit/cf9b36f3d97b6f9c66ffff008bc1b5a5dd14ca98

vim-artemis expects that `vim.list` is function, so we got the following error:

```
Loading state error: Vim(lua):E5108: Lua: ...he/dpp/repos/github.com/tani/vim-artemis/lua/artemis.lua:117: attempt to call field 'list' (a table value)
```

For the above reasons, we check that it is function.

Similarly, `vim.dict` and `vim.blob` have been modified for symmetry.